### PR TITLE
Block-Jacobi preconditioning, Eisenstat-Walker for inexact steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,16 @@ problems. We accelerate optimization by analyzing the structure of graphs:
 repeated factor and variable types are vectorized, and the sparsity of adjacency
 in the graph is translated into sparse matrix operations.
 
-Features:
+Currently supported:
 
 - Automatic sparse Jacobians.
 - Optimization on manifolds; SO(2), SO(3), SE(2), and SE(3) implementations
   included.
 - Nonlinear solvers: Levenberg-Marquardt and Gauss-Newton.
-- Linear solvers: both direct (sparse Cholesky via CHOLMOD, on CPU) and
-  iterative (Conjugate Gradient).
-- Preconditioning: block and point Jacobi.
+- Direct linear solves via sparse Cholesky / CHOLMOD, on CPU.
+- Iterative linear solves via Conjugate Gradient.
+  - Preconditioning: block and point Jacobi.
+  - Inexact Newton via Eisenstat-Walker.
 
 Use cases are primarily in least squares problems that are inherently (1)
 sparse and (2) inefficient to solve with gradient-based methods. These are

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![pyright](https://github.com/brentyi/jaxls/actions/workflows/pyright.yml/badge.svg)](https://github.com/brentyi/jaxls/actions/workflows/pyright.yml)
 
-_status: working! see limitations [here](#limitations)_ 
+_status: working! see limitations [here](#limitations)_
 
 **`jaxls`** is a library for nonlinear least squares in JAX.
 
@@ -18,11 +18,12 @@ Features:
   included.
 - Nonlinear solvers: Levenberg-Marquardt and Gauss-Newton.
 - Linear solvers: both direct (sparse Cholesky via CHOLMOD, on CPU) and
-  iterative (Jacobi-preconditioned Conjugate Gradient).
+  iterative (Conjugate Gradient).
+- Preconditioning: block and point Jacobi.
 
-Use cases are primarily in least squares problems that are inherently (1) sparse
-and (2) inefficient to solve with gradient-based methods. In robotics, these are
-ubiquitous across classical approaches to perception, planning, and control.
+Use cases are primarily in least squares problems that are inherently (1)
+sparse and (2) inefficient to solve with gradient-based methods. These are
+common in robotics.
 
 For the first iteration of this library, written for
 [IROS 2021](https://github.com/brentyi/dfgo), see
@@ -122,6 +123,7 @@ print("Pose 1", solution[pose_vars[1]])
 ### Limitations
 
 There are many practical features that we don't currently support:
+
 - GPU accelerated Cholesky factorization. (for CHOLMOD we wrap [scikit-sparse](https://scikit-sparse.readthedocs.io/en/latest/), which runs on CPU only)
 - Covariance estimation / marginalization.
 - Incremental solves.

--- a/src/jaxls/_preconditioning.py
+++ b/src/jaxls/_preconditioning.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
+import jax
+from jax import numpy as jnp
+
+if TYPE_CHECKING:
+    from ._factor_graph import FactorGraph
+    from ._sparse_matrices import BlockRowSparseMatrix
+
+
+def make_jacobi_precoditioner(
+    A_blocksparse: BlockRowSparseMatrix,
+) -> Callable[[jax.Array], jax.Array]:
+    """Returns a diagonal Jacobi preconditioner."""
+    ATA_diagonals = jnp.zeros(A_blocksparse.shape[1])
+
+    for block_row in A_blocksparse.block_rows:
+        (n_blocks, rows, cols_concat) = block_row.blocks_concat.shape
+        del rows
+        del cols_concat
+        assert block_row.blocks_concat.ndim == 3  # (N_block, rows, cols)
+        assert block_row.start_cols[0].shape == (n_blocks,)
+        block_l2_cols = jnp.sum(block_row.blocks_concat**2, axis=1).flatten()
+        indices = jnp.concatenate(
+            [
+                (start_col[:, None] + jnp.arange(width)[None, :])
+                for start_col, width in zip(
+                    block_row.start_cols, block_row.block_widths
+                )
+            ],
+            axis=1,
+        ).flatten()
+        ATA_diagonals = ATA_diagonals.at[indices].add(block_l2_cols)
+
+    return lambda vec: vec / ATA_diagonals
+
+
+def make_block_jacobi_precoditioner(
+    graph: FactorGraph, A_blocksparse: BlockRowSparseMatrix
+) -> Callable[[jax.Array], jax.Array]:
+    """Returns a Block-Jacobi preconditioner."""
+
+    # This list will store block diagonal gram matrices corresponding to each
+    # variable.
+    gram_diagonal_blocks = list[jax.Array]()
+    for var_type, ids in graph.tangent_ordering.ordered_dict_items(
+        graph.sorted_ids_from_var_type
+    ):
+        (num_vars,) = ids.shape
+        gram_diagonal_blocks.append(
+            jnp.zeros((num_vars, var_type.tangent_dim, var_type.tangent_dim))
+            + jnp.eye(var_type.tangent_dim) * 1e-6
+        )
+
+    assert len(graph.stacked_factors) == len(A_blocksparse.block_rows)
+    for factor, block_row in zip(graph.stacked_factors, A_blocksparse.block_rows):
+        assert block_row.blocks_concat.ndim == 3  # (N_block, rows, cols)
+
+        # Current index we're looking at in the blocks_concat array.
+        start_concat_col = 0
+
+        for var_type, ids in graph.tangent_ordering.ordered_dict_items(
+            factor.sorted_ids_from_var_type
+        ):
+            (num_factors, num_vars) = ids.shape
+            var_type_idx = graph.tangent_ordering.order_from_type[var_type]
+
+            # Extract the blocks corresponding to the current variable type.
+            end_concat_col = start_concat_col + num_vars * var_type.tangent_dim
+            A_blocks = block_row.blocks_concat[
+                :, :, start_concat_col:end_concat_col
+            ].reshape(
+                (
+                    num_factors,
+                    factor.residual_dim,
+                    num_vars,
+                    var_type.tangent_dim,
+                )
+            )
+
+            # f: factor, r: residual, v: variable, t/a: tangent
+            gram_blocks = jnp.einsum("frvt,frva->fvta", A_blocks, A_blocks)
+            assert gram_blocks.shape == (
+                num_factors,
+                num_vars,
+                factor.residual_dim,
+                factor.residual_dim,
+            )
+
+            start_concat_col = end_concat_col
+            del end_concat_col
+
+            gram_diagonal_blocks[var_type_idx] = (
+                gram_diagonal_blocks[var_type_idx]
+                .at[jnp.searchsorted(graph.sorted_ids_from_var_type[var_type], ids)]
+                .add(gram_blocks)
+            )
+
+    inv_block_diagonals = [
+        jnp.linalg.inv(batched_block) for batched_block in gram_diagonal_blocks
+    ]
+
+    def preconditioner(vec: jax.Array) -> jax.Array:
+        """Compute Block-Jacobi preconditioning."""
+        precond_parts = []
+        offset = 0
+        for inv_batched_block in inv_block_diagonals:
+            num_blocks, block_dim, block_dim_ = inv_batched_block.shape
+            assert block_dim == block_dim_
+            precond_parts.append(
+                jnp.einsum(
+                    "bij,bj->bi",
+                    inv_batched_block,
+                    vec[offset : offset + num_blocks * block_dim].reshape(
+                        (num_blocks, block_dim)
+                    ),
+                ).flatten()
+            )
+            offset += num_blocks * block_dim
+        out = jnp.concatenate(precond_parts, axis=0)
+        assert out.shape == vec.shape
+        return out
+
+    return preconditioner

--- a/src/jaxls/_preconditioning.py
+++ b/src/jaxls/_preconditioning.py
@@ -10,10 +10,10 @@ if TYPE_CHECKING:
     from ._sparse_matrices import BlockRowSparseMatrix
 
 
-def make_jacobi_precoditioner(
+def make_point_jacobi_precoditioner(
     A_blocksparse: BlockRowSparseMatrix,
 ) -> Callable[[jax.Array], jax.Array]:
-    """Returns a diagonal Jacobi preconditioner."""
+    """Returns a point Jacobi (diagonal) preconditioner."""
     ATA_diagonals = jnp.zeros(A_blocksparse.shape[1])
 
     for block_row in A_blocksparse.block_rows:
@@ -40,7 +40,7 @@ def make_jacobi_precoditioner(
 def make_block_jacobi_precoditioner(
     graph: FactorGraph, A_blocksparse: BlockRowSparseMatrix
 ) -> Callable[[jax.Array], jax.Array]:
-    """Returns a Block-Jacobi preconditioner."""
+    """Returns a block Jacobi preconditioner."""
 
     # This list will store block diagonal gram matrices corresponding to each
     # variable.
@@ -103,7 +103,7 @@ def make_block_jacobi_precoditioner(
     ]
 
     def preconditioner(vec: jax.Array) -> jax.Array:
-        """Compute Block-Jacobi preconditioning."""
+        """Compute block Jacobi preconditioning."""
         precond_parts = []
         offset = 0
         for inv_batched_block in inv_block_diagonals:

--- a/src/jaxls/_solvers.py
+++ b/src/jaxls/_solvers.py
@@ -91,7 +91,9 @@ class ConjugateGradientLinearSolver:
     For reference, see AN INEXACT LEVENBERG-MARQUARDT METHOD FOR LARGE SPARSE NONLINEAR
     LEAST SQUARES, Wright & Holt 1983."""
 
-    preconditioner: jdc.Static[Literal["block-jacobi", "point-jacobi"]] | None = "block-jacobi"
+    preconditioner: jdc.Static[Literal["block-jacobi", "point-jacobi"] | None] = (
+        "block-jacobi"
+    )
     """Preconditioner to use for linear solves."""
 
     def _solve(

--- a/src/jaxls/_solvers.py
+++ b/src/jaxls/_solvers.py
@@ -14,7 +14,7 @@ from jax import numpy as jnp
 
 from jaxls._preconditioning import (
     make_block_jacobi_precoditioner,
-    make_jacobi_precoditioner,
+    make_point_jacobi_precoditioner,
 )
 
 from ._sparse_matrices import BlockRowSparseMatrix, SparseCsrMatrix
@@ -91,7 +91,7 @@ class ConjugateGradientLinearSolver:
     For reference, see AN INEXACT LEVENBERG-MARQUARDT METHOD FOR LARGE SPARSE NONLINEAR
     LEAST SQUARES, Wright & Holt 1983."""
 
-    preconditioner: Literal["block-jacobi", "jacobi"] | None = "block-jacobi"
+    preconditioner: Literal["block-jacobi", "point-jacobi"] | None = "block-jacobi"
     """Preconditioner to use for linear solves."""
 
     def _solve(
@@ -107,8 +107,8 @@ class ConjugateGradientLinearSolver:
         # Preconditioning setup.
         if self.preconditioner == "block-jacobi":
             preconditioner = make_block_jacobi_precoditioner(graph, A_blocksparse)
-        elif self.preconditioner == "jacobi":
-            preconditioner = make_jacobi_precoditioner(A_blocksparse)
+        elif self.preconditioner == "point-jacobi":
+            preconditioner = make_point_jacobi_precoditioner(A_blocksparse)
         elif self.preconditioner is None:
             preconditioner = lambda x: x
         else:

--- a/src/jaxls/_solvers.py
+++ b/src/jaxls/_solvers.py
@@ -91,7 +91,7 @@ class ConjugateGradientLinearSolver:
     For reference, see AN INEXACT LEVENBERG-MARQUARDT METHOD FOR LARGE SPARSE NONLINEAR
     LEAST SQUARES, Wright & Holt 1983."""
 
-    preconditioner: Literal["block-jacobi", "point-jacobi"] | None = "block-jacobi"
+    preconditioner: jdc.Static[Literal["block-jacobi", "point-jacobi"]] | None = "block-jacobi"
     """Preconditioner to use for linear solves."""
 
     def _solve(


### PR DESCRIPTION
More improvements for the CG-based solves.

Some numbers before/after recent changes, on M3500:

- CPU (M1 Pro)
  - Before: 31.033 seconds, cost 137.9171
  - After: 1.569 seconds, cost 137.9478
- GPU (RTX 4090)
  - Before: 0.883 seconds, cost 137.9149
  - After: 0.412 seconds, cost 137.9178