### PR TITLE
Add Python 3.10 compatibility

### DIFF
--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.10", "3.12"]
 
     steps:
       - uses: actions/checkout@v2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# jaxls Development Guidelines
+
+## Commands
+- Install: `pip install -e ".[dev]"`
+- Type checking: `pyright .`
+- Linting: `ruff .`
+- Run example: `python examples/pose_graph_simple.py`
+- Run specific test: `python examples/test_cache.py`
+
+## Code Style
+- Use Python 3.10+ features
+- Follow PEP 8 naming conventions: snake_case for functions/variables, PascalCase for classes
+- Type annotations required for all functions and classes
+- Import order: standard lib → third-party → local modules
+- Use relative imports within the package
+- Factor graph code uses dataclasses and functional style
+- Error handling should use assertions for preconditions
+- Documentation in docstrings should follow NumPy style
+- Leverage JAX's functional programming paradigm
+- Vectorize operations where possible for performance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,10 @@ version = "0.0.0"
 description = "Nonlinear least squares with JAX"
 readme = "README.md"
 license = { text="MIT" }
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 classifiers = [
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent"

--- a/src/jaxls/_solvers.py
+++ b/src/jaxls/_solvers.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import functools
-from typing import TYPE_CHECKING, Callable, Hashable, Literal, assert_never, cast
+from typing import TYPE_CHECKING, Callable, Hashable, Literal, cast
+from typing_extensions import assert_never
 
 import jax
 import jax.experimental.sparse


### PR DESCRIPTION
## Summary
- Add Python 3.10 compatibility while maintaining Python 3.12 support
- Replace star operator syntax for variadic generics with typing_extensions solution
- Use TypeVarTuple and Unpack for variadic generic type parameters
- Move assert_never import from typing to typing_extensions
- Update GitHub workflow to test with Python 3.10 and 3.12
- Add CLAUDE.md with development guidelines

## Detailed Changes

### Type Variable Handling
- Added explicit `TypeVarTuple` and `Unpack` imports from `typing_extensions`
- Defined type variables at module level (Ts, T)
- Updated generic class definitions to use compatible syntax

### Project Configuration
- Updated `pyproject.toml` to specify minimum Python version as 3.10
- Added Python 3.10 to the supported Python classifiers

### Type Casting and Type Hints
- Added appropriate type casts for Python 3.10 compatibility
- Used explicit type annotations where Python 3.10's type checker is more strict

### CI Configuration
- Added Python 3.10 to the GitHub workflows test matrix

This PR enables the library to be used with Python 3.10 without sacrificing the modern type annotation capabilities. It maintains backward compatibility while leveraging `typing_extensions` to access newer type annotation features in older Python versions.

🤖 Generated with Claude Code