### PR TITLE
Support intermediate reuse between residual and custom Jacobian functions

### DIFF
--- a/src/jaxls/_core.py
+++ b/src/jaxls/_core.py
@@ -337,17 +337,17 @@ class AnalyzedLeastSquaresProblem:
         jac_cache = list[CustomJacobianCache]()
         for stacked_cost in self.stacked_costs:
             # Flatten the output of the user-provided compute_residual.
-            stacked_residual_slice = jax.vmap(
+            compute_residual_out = jax.vmap(
                 lambda args: stacked_cost.compute_residual_flat(vals, *args)
             )(stacked_cost.args)
 
-            if isinstance(stacked_residual_slice, tuple):
-                assert len(stacked_residual_slice) == 2
-                residual_slices.append(stacked_residual_slice[0])
-                jac_cache.append(stacked_residual_slice[1])
+            if isinstance(compute_residual_out, tuple):
+                assert len(compute_residual_out) == 2
+                residual_slices.append(compute_residual_out[0])
+                jac_cache.append(compute_residual_out[1])
             else:
-                assert len(stacked_residual_slice.shape) == 2
-                residual_slices.append(stacked_residual_slice.reshape((-1,)))
+                assert len(compute_residual_out.shape) == 2
+                residual_slices.append(compute_residual_out.reshape((-1,)))
                 jac_cache.append(None)
 
         if include_jac_cache:

--- a/src/jaxls/_core.py
+++ b/src/jaxls/_core.py
@@ -465,17 +465,17 @@ type ResidualFunc[**Args] = Callable[
     Concatenate[VarValues, Args],
     jax.Array,
 ]
-type ResidualFuncWithJacCache[**Args] = Callable[
+type ResidualFuncWithJacCache[**Args, TJacobianCache: CustomJacobianCache] = Callable[
     Concatenate[VarValues, Args],
-    tuple[jax.Array, CustomJacobianCache],
+    tuple[jax.Array, TJacobianCache],
 ]
 
 type JacobianFunc[**Args] = Callable[
     Concatenate[VarValues, Args],
     jax.Array,
 ]
-type JacobianFuncWithCache[**Args] = Callable[
-    Concatenate[VarValues, CustomJacobianCache, Args],
+type JacobianFuncWithCache[**Args, TJacobianCache: CustomJacobianCache] = Callable[
+    Concatenate[VarValues, TJacobianCache, Args],
     jax.Array,
 ]
 
@@ -612,12 +612,14 @@ class Cost[*Args]:
     # `jac_mode` is ignored in this case.
     @overload
     @staticmethod
-    def create_factory[**Args_](
+    def create_factory[**Args_, TJacobianCache](
         *,
-        jac_custom_with_cache_fn: JacobianFuncWithCache[Args_],
+        jac_custom_with_cache_fn: JacobianFuncWithCache[Args_, TJacobianCache],
         jac_batch_size: int | None = None,
         name: str | None = None,
-    ) -> Callable[[ResidualFuncWithJacCache[Args_]], CostFactory[Args_]]: ...
+    ) -> Callable[
+        [ResidualFuncWithJacCache[Args_, TJacobianCache]], CostFactory[Args_]
+    ]: ...
 
     @staticmethod
     def create_factory[**Args_](
@@ -626,11 +628,11 @@ class Cost[*Args]:
         jac_mode: Literal["auto", "forward", "reverse"] = "auto",
         jac_batch_size: int | None = None,
         jac_custom_fn: JacobianFunc[Args_] | None = None,
-        jac_custom_with_cache_fn: JacobianFuncWithCache[Args_] | None = None,
+        jac_custom_with_cache_fn: JacobianFuncWithCache[Args_, Any] | None = None,
         name: str | None = None,
     ) -> (
         Callable[[ResidualFunc[Args_]], CostFactory[Args_]]
-        | Callable[[ResidualFuncWithJacCache[Args_]], CostFactory[Args_]]
+        | Callable[[ResidualFuncWithJacCache[Args_, Any]], CostFactory[Args_]]
         | CostFactory[Args_]
     ):
         """Decorator for creating costs from a residual function.

--- a/src/jaxls/_core.py
+++ b/src/jaxls/_core.py
@@ -319,26 +319,51 @@ class AnalyzedLeastSquaresProblem:
         )
         return solver.solve(problem=self, initial_vals=initial_vals)
 
-    def compute_residual_vector(self, vals: VarValues) -> jax.Array:
+    @overload
+    def compute_residual_vector(
+        self, vals: VarValues, include_jac_cache: Literal[True]
+    ) -> tuple[jax.Array, CustomJacobianCache]: ...
+    @overload
+    def compute_residual_vector(
+        self, vals: VarValues, include_jac_cache: Literal[False] = False
+    ) -> jax.Array | tuple[jax.Array, tuple[CustomJacobianCache, ...]]: ...
+
+    def compute_residual_vector(
+        self, vals: VarValues, include_jac_cache: bool = False
+    ) -> jax.Array | tuple[jax.Array, tuple[CustomJacobianCache, ...]]:
         """Compute the residual vector. The cost we are optimizing is defined
         as the sum of squared terms within this vector."""
         residual_slices = list[jax.Array]()
+        jac_cache = list[CustomJacobianCache]()
         for stacked_cost in self.stacked_costs:
             # Flatten the output of the user-provided compute_residual.
             stacked_residual_slice = jax.vmap(
                 lambda args: stacked_cost.compute_residual_flat(vals, *args)
             )(stacked_cost.args)
-            assert len(stacked_residual_slice.shape) == 2
-            residual_slices.append(stacked_residual_slice.reshape((-1,)))
-        return jnp.concatenate(residual_slices, axis=0)
 
-    def _compute_jac_values(self, vals: VarValues) -> BlockRowSparseMatrix:
+            if isinstance(stacked_residual_slice, tuple):
+                assert len(stacked_residual_slice) == 2
+                residual_slices.append(stacked_residual_slice[0])
+                jac_cache.append(stacked_residual_slice[1])
+            else:
+                assert len(stacked_residual_slice.shape) == 2
+                residual_slices.append(stacked_residual_slice.reshape((-1,)))
+                jac_cache.append(None)
+
+        if include_jac_cache:
+            return jnp.concatenate(residual_slices, axis=0), tuple(jac_cache)
+        else:
+            return jnp.concatenate(residual_slices, axis=0)
+
+    def _compute_jac_values(
+        self, vals: VarValues, jac_cache: tuple[CustomJacobianCache, ...]
+    ) -> BlockRowSparseMatrix:
         block_rows = list[SparseBlockRow]()
         residual_offset = 0
 
-        for cost in self.stacked_costs:
+        for i, cost in enumerate(self.stacked_costs):
             # Shape should be: (count_from_group[group_key], single_residual_dim, sum_of_tangent_dims_of_variables).
-            def compute_jac_with_perturb(cost: _AnalyzedCost) -> jax.Array:
+            def compute_jac_with_perturb(cost: _AnalyzedCost, i: int = i) -> jax.Array:
                 val_subset = vals._get_subset(
                     {
                         var_type: jnp.searchsorted(vals.ids_from_type[var_type], ids)
@@ -349,7 +374,11 @@ class AnalyzedLeastSquaresProblem:
 
                 # Shape should be: (residual_dim, sum_of_tangent_dims_of_variables).
                 if cost.jac_custom_fn is not None:
+                    assert jac_cache[i] is not None
                     return cost.jac_custom_fn(vals, *cost.args)
+                if cost.jac_custom_with_cache_fn is not None:
+                    assert jac_cache[i] is not None
+                    return cost.jac_custom_with_cache_fn(vals, jac_cache[i], *cost.args)
 
                 jacfunc = {
                     "forward": jax.jacfwd,
@@ -430,15 +459,49 @@ class AnalyzedLeastSquaresProblem:
         return bsparse_jacobian
 
 
-type ResidualFunc[**Args] = Callable[Concatenate[VarValues, Args], jax.Array]
-type JacobianFunc[**Args] = Callable[Concatenate[VarValues, Args], jax.Array]
-type CostFactory[**Args] = Callable[Args, Cost[tuple[Any, ...], dict[str, Any]]]
+CustomJacobianCache = Any
+
+type ResidualFunc[**Args] = Callable[
+    Concatenate[VarValues, Args],
+    jax.Array,
+]
+type ResidualFuncWithJacCache[**Args] = Callable[
+    Concatenate[VarValues, Args],
+    tuple[jax.Array, CustomJacobianCache],
+]
+
+type JacobianFunc[**Args] = Callable[
+    Concatenate[VarValues, Args],
+    jax.Array,
+]
+type JacobianFuncWithCache[**Args] = Callable[
+    Concatenate[VarValues, CustomJacobianCache, Args],
+    jax.Array,
+]
+
+type CostFactory[**Args] = Callable[
+    Args,
+    Cost[tuple[Any, ...], dict[str, Any]],
+]
 
 
 @jdc.pytree_dataclass
 class Cost[*Args]:
     """A least squares cost term in our optimization problem, defined by a
-    residual function. The cost that this represents is defined as:
+    residual function.
+
+    The recommended way to create a cost is to use the `create_factory` decorator
+    on a function that computes the residual:
+
+
+    ```python
+    @Cost.create_factory
+    def compute_residual(values: VarValues, [...args]) -> jax.Array:
+        # Compute residual vector/array.
+        return residual
+    ```
+
+    The cost that this represents is defined as:
 
          || compute_residual(values, *args) ||_2^2
 
@@ -450,26 +513,55 @@ class Cost[*Args]:
 
     To create a batch of costs, a leading batch axis can be added to the
     arguments passed to `Cost.args`:
-    - The batch axis must be the same for all arguments.
-    -
+    - The batch axis must be the same for all arguments. Leading axes of shape
+      `(1,)` are broadcasted.
+    - The `id` field of each `jaxls.Var` instance must have shape of either
+      `()` (unbatched) or `(batch_size,)` (batched).
     """
 
-    compute_residual: jdc.Static[Callable[[VarValues, *Args], jax.Array]]
+    compute_residual: jdc.Static[
+        Callable[[VarValues, *Args], jax.Array]
+        | Callable[[VarValues, *Args], tuple[jax.Array, CustomJacobianCache]]
+    ]
+    """Residual computation function. Can either return:
+        1. A residual vector, or
+        2. A tuple, where the tuple values should be (residual, jacobian_cache).
+
+    The latter is useful when custom Jacobian computation benefits from
+    intermediate values computed during the residual computation.
+
+    `jac_custom_with_cache_fn` should be specified in the second case,
+    and will be expected to take arguments in the form `(values,
+    jacobian_cache, *args)`."""
+
     args: tuple[*Args]
+    """Arguments to the residual function. This should include at least one
+    `jaxls.Var` object, which can either in the root of the tuple or nested
+    within a PyTree structure arbitrarily."""
+
     jac_mode: jdc.Static[Literal["auto", "forward", "reverse"]] = "auto"
     """Depending on the function being differentiated, it may be faster to use
     forward-mode or reverse-mode autodiff. Ignored if `jac_custom_fn` is
     specified."""
+
     jac_batch_size: jdc.Static[int | None] = None
     """Batch size for computing Jacobians that can be parallelized. Can be set
     to make tradeoffs between runtime and memory usage.
 
     If None, we compute all Jacobians in parallel. If 1, we compute Jacobians
     one at a time."""
+
     jac_custom_fn: jdc.Static[Callable[[VarValues, *Args], jax.Array] | None] = None
     """Optional custom Jacobian function. If None, we use autodiff. Inputs are
     the same as `compute_residual`. Output is a single 2D Jacobian matrix with
     shape (residual_dim, sum_of_tangent_dims_of_variables)."""
+
+    jac_custom_with_cache_fn: jdc.Static[
+        Callable[[VarValues, CustomJacobianCache, *Args], jax.Array] | None
+    ] = None
+    """Optional custom Jacobian function. The same as `jac_custom_fn`, but
+    should be used when `compute_residual` returns a tuple with
+    cache."""
 
     name: jdc.Static[str | None] = None
     """Custom name for the cost. This is used for debugging and logging."""
@@ -493,21 +585,47 @@ class Cost[*Args]:
     @staticmethod
     def create_factory[**Args_](
         *,
-        jac_mode: jdc.Static[Literal["auto", "forward", "reverse"]] = "auto",
-        jac_batch_size: jdc.Static[int | None] = None,
-        jac_custom_fn: jdc.Static[JacobianFunc | None] = None,
-        name: jdc.Static[str | None] = None,
+        jac_mode: Literal["auto", "forward", "reverse"] = "auto",
+        jac_batch_size: int | None = None,
+        name: str | None = None,
     ) -> Callable[[ResidualFunc[Args_]], CostFactory[Args_]]: ...
+
+    # Decorator factory with keyword arguments + custom Jacobian.
+    # `jac_mode` is ignored in this case.
+    @overload
+    @staticmethod
+    def create_factory[**Args_](
+        *,
+        jac_custom_fn: None = None,
+        jac_batch_size: int | None = None,
+        name: str | None = None,
+    ) -> Callable[[ResidualFunc[Args_]], CostFactory[Args_]]: ...
+
+    # Decorator factory with keyword arguments + custom Jacobian with cache.
+    # `jac_mode` is ignored in this case.
+    @overload
+    @staticmethod
+    def create_factory[**Args_](
+        *,
+        jac_custom_with_cache_fn: JacobianFuncWithCache[Args_],
+        jac_batch_size: int | None = None,
+        name: str | None = None,
+    ) -> Callable[[ResidualFuncWithJacCache[Args_]], CostFactory[Args_]]: ...
 
     @staticmethod
     def create_factory[**Args_](
         compute_residual: ResidualFunc[Args_] | None = None,
         *,
-        jac_mode: jdc.Static[Literal["auto", "forward", "reverse"]] = "auto",
-        jac_batch_size: jdc.Static[int | None] = None,
-        jac_custom_fn: jdc.Static[JacobianFunc | None] = None,
-        name: jdc.Static[str | None] = None,
-    ) -> Callable[[ResidualFunc[Args_]], CostFactory[Args_]] | CostFactory[Args_]:
+        jac_mode: Literal["auto", "forward", "reverse"] = "auto",
+        jac_batch_size: int | None = None,
+        jac_custom_fn: JacobianFunc[Args_] | None = None,
+        jac_custom_with_cache_fn: JacobianFuncWithCache[Args_] | None = None,
+        name: str | None = None,
+    ) -> (
+        Callable[[ResidualFunc[Args_]], CostFactory[Args_]]
+        | Callable[[ResidualFuncWithJacCache[Args_]], CostFactory[Args_]]
+        | CostFactory[Args_]
+    ):
         """Decorator for creating costs from a residual function.
 
         Examples:
@@ -553,6 +671,14 @@ class Cost[*Args]:
                         )(values, *args, **kwargs)
                     )
                     if jac_custom_fn is not None
+                    else None,
+                    jac_custom_with_cache_fn=(
+                        lambda values, cache, args, kwargs: cast(
+                            JacobianFuncWithCache[Args_],
+                            jac_custom_with_cache_fn,
+                        )(values, cache, *args, **kwargs)
+                    )
+                    if jac_custom_with_cache_fn is not None
                     else None,
                     name=name,
                 )
@@ -626,8 +752,19 @@ class _AnalyzedCost[*Args](Cost[*Args]):
     sorted_ids_from_var_type: dict[type[Var[Any]], jax.Array]
     residual_flat_dim: jdc.Static[int] = 0
 
-    def compute_residual_flat(self, vals: VarValues, *args: *Args) -> jax.Array:
-        return self.compute_residual(vals, *args).flatten()
+    def compute_residual_flat(
+        self, vals: VarValues, *args: *Args
+    ) -> jax.Array | tuple[jax.Array, CustomJacobianCache]:
+        out = self.compute_residual(vals, *args)
+
+        # Flatten residual vector.
+        if isinstance(out, tuple):
+            assert len(out) == 2
+            out = (out[0].flatten(), out[1])
+        else:
+            out = out.flatten()
+
+        return out
 
     @staticmethod
     @jdc.jit

--- a/src/jaxls/_core.py
+++ b/src/jaxls/_core.py
@@ -491,14 +491,21 @@ class Cost[*Args]:
     residual function.
 
     The recommended way to create a cost is to use the `create_factory` decorator
-    on a function that computes the residual:
+    on a function that computes the residual. This will transform the input function
+    into a "factory" functinos that returns `Cost` objects.
 
 
     ```python
-    @Cost.create_factory
+    @jaxls.Cost.create_factory
     def compute_residual(values: VarValues, [...args]) -> jax.Array:
         # Compute residual vector/array.
         return residual
+
+    # `compute_residual()` is now a factory function that returns `jaxls.Cost` objects.
+    problem = jaxls.LeastSquaresProblem(
+        costs=[compute_residual(...), ...],
+        variables=[...],
+    )
     ```
 
     The cost that this represents is defined as:
@@ -527,7 +534,7 @@ class Cost[*Args]:
         1. A residual vector, or
         2. A tuple, where the tuple values should be (residual, jacobian_cache).
 
-    The latter is useful when custom Jacobian computation benefits from
+    The second option is useful when custom Jacobian computation benefits from
     intermediate values computed during the residual computation.
 
     `jac_custom_with_cache_fn` should be specified in the second case,

--- a/src/jaxls/_core.py
+++ b/src/jaxls/_core.py
@@ -683,7 +683,7 @@ class Cost[*Args]:
                     else None,
                     jac_custom_with_cache_fn=(
                         lambda values, cache, args, kwargs: cast(
-                            JacobianFuncWithCache[Args_],
+                            JacobianFuncWithCache[Args_, Any],
                             jac_custom_with_cache_fn,
                         )(values, cache, *args, **kwargs)
                     )

--- a/src/jaxls/_core.py
+++ b/src/jaxls/_core.py
@@ -375,14 +375,14 @@ class AnalyzedLeastSquaresProblem:
 
                 # Shape should be: (residual_dim, sum_of_tangent_dims_of_variables).
                 if cost.jac_custom_fn is not None:
-                    assert (
-                        jac_cache[i] is None
-                    ), "`jac_custom_with_cache_fn` should be used if a Jacobian cache is used, not `jac_custom_fn`!"
+                    assert jac_cache[i] is None, (
+                        "`jac_custom_with_cache_fn` should be used if a Jacobian cache is used, not `jac_custom_fn`!"
+                    )
                     return cost.jac_custom_fn(vals, *cost.args)
                 if cost.jac_custom_with_cache_fn is not None:
-                    assert (
-                        jac_cache[i] is not None
-                    ), "`jac_custom_with_cache_fn` was specified, but no cache was returned by `compute_residual`!"
+                    assert jac_cache[i] is not None, (
+                        "`jac_custom_with_cache_fn` was specified, but no cache was returned by `compute_residual`!"
+                    )
                     return cost.jac_custom_with_cache_fn(vals, jac_cache[i], *cost.args)
 
                 jacfunc = {

--- a/src/jaxls/_core.py
+++ b/src/jaxls/_core.py
@@ -323,6 +323,7 @@ class AnalyzedLeastSquaresProblem:
     def compute_residual_vector(
         self, vals: VarValues, include_jac_cache: Literal[True]
     ) -> tuple[jax.Array, CustomJacobianCache]: ...
+
     @overload
     def compute_residual_vector(
         self, vals: VarValues, include_jac_cache: Literal[False] = False
@@ -374,14 +375,14 @@ class AnalyzedLeastSquaresProblem:
 
                 # Shape should be: (residual_dim, sum_of_tangent_dims_of_variables).
                 if cost.jac_custom_fn is not None:
-                    assert jac_cache[i] is None, (
-                        "`jac_custom_with_cache_fn` should be used if a Jacobian cache is used, not `jac_custom_fn`!"
-                    )
+                    assert (
+                        jac_cache[i] is None
+                    ), "`jac_custom_with_cache_fn` should be used if a Jacobian cache is used, not `jac_custom_fn`!"
                     return cost.jac_custom_fn(vals, *cost.args)
                 if cost.jac_custom_with_cache_fn is not None:
-                    assert jac_cache[i] is not None, (
-                        "`jac_custom_with_cache_fn` was specified, but no cache was returned by `compute_residual`!"
-                    )
+                    assert (
+                        jac_cache[i] is not None
+                    ), "`jac_custom_with_cache_fn` was specified, but no cache was returned by `compute_residual`!"
                     return cost.jac_custom_with_cache_fn(vals, jac_cache[i], *cost.args)
 
                 jacfunc = {

--- a/src/jaxls/_solvers.py
+++ b/src/jaxls/_solvers.py
@@ -10,7 +10,6 @@ import scipy
 import scipy.sparse
 from jax import numpy as jnp
 
-from jaxls._core import CustomJacobianCache
 from jaxls._preconditioning import (
     make_block_jacobi_precoditioner,
     make_point_jacobi_precoditioner,
@@ -23,7 +22,7 @@ from .utils import jax_log
 if TYPE_CHECKING:
     import sksparse.cholmod
 
-    from ._core import AnalyzedLeastSquaresProblem
+    from ._core import AnalyzedLeastSquaresProblem, CustomJacobianCache
 
 
 _cholmod_analyze_cache: dict[Hashable, sksparse.cholmod.Factor] = {}

--- a/src/jaxls/_solvers.py
+++ b/src/jaxls/_solvers.py
@@ -10,6 +10,7 @@ import scipy
 import scipy.sparse
 from jax import numpy as jnp
 
+from jaxls._core import CustomJacobianCache
 from jaxls._preconditioning import (
     make_block_jacobi_precoditioner,
     make_point_jacobi_precoditioner,
@@ -176,8 +177,12 @@ class NonlinearSolverState:
     termination_deltas: jax.Array
     lambd: float | jax.Array
 
-    # Conjugate gradient state. Not used for other solvers.
+    jac_cache: tuple[CustomJacobianCache, ...]
+    """Cache used to save intermediate values from `compute_residual_vector`
+    for use in custom Jacobians."""
+
     cg_state: _ConjugateGradientState | None
+    """Conjugate gradient state. Not used for other solvers."""
 
 
 @jdc.pytree_dataclass
@@ -198,7 +203,9 @@ class NonlinearSolver:
         self, problem: AnalyzedLeastSquaresProblem, initial_vals: VarValues
     ) -> VarValues:
         vals = initial_vals
-        residual_vector = problem.compute_residual_vector(vals)
+        residual_vector, jac_cache = problem.compute_residual_vector(
+            vals, include_jac_cache=True
+        )
 
         state = NonlinearSolverState(
             iterations=0,
@@ -220,6 +227,7 @@ class NonlinearSolver:
                     else self.conjugate_gradient_config
                 ).tolerance_max,
             ),
+            jac_cache=jac_cache,
         )
 
         # Optimization.
@@ -243,8 +251,12 @@ class NonlinearSolver:
     def step(
         self, problem: AnalyzedLeastSquaresProblem, state: NonlinearSolverState
     ) -> NonlinearSolverState:
+        # Log optimizer state for debugging.
+        if self.verbose:
+            self._log_state(problem, state)
+
         # Get nonzero values of Jacobian.
-        A_blocksparse = problem._compute_jac_values(state.vals)
+        A_blocksparse = problem._compute_jac_values(state.vals, state.jac_cache)
 
         # Get flattened version for COO/CSR matrices.
         jac_values = jnp.concatenate(
@@ -319,50 +331,11 @@ class NonlinearSolver:
         else:
             assert_never(self.linear_solver)
 
-        vals = state.vals._retract(local_delta, problem.tangent_ordering)
-        if self.verbose:
-            if state.cg_state is None:
-                jax_log(
-                    " step #{i}: cost={cost:.4f} lambd={lambd:.4f} term_deltas={cost_delta:.1e},{grad_mag:.1e},{param_delta:.1e}",
-                    i=state.iterations,
-                    cost=state.cost,
-                    lambd=state.lambd,
-                    cost_delta=state.termination_deltas[0],
-                    grad_mag=state.termination_deltas[1],
-                    param_delta=state.termination_deltas[2],
-                    ordered=True,
-                )
-            else:
-                jax_log(
-                    " step #{i}: cost={cost:.4f} lambd={lambd:.4f} term_deltas={cost_delta:.1e},{grad_mag:.1e},{param_delta:.1e} inexact_tol={inexact_tol:.1e}",
-                    i=state.iterations,
-                    cost=state.cost,
-                    lambd=state.lambd,
-                    cost_delta=state.termination_deltas[0],
-                    grad_mag=state.termination_deltas[1],
-                    param_delta=state.termination_deltas[2],
-                    inexact_tol=state.cg_state.eta,
-                    ordered=True,
-                )
-            residual_index = 0
-            for f, count in zip(problem.stacked_costs, problem.cost_counts):
-                stacked_dim = count * f.residual_flat_dim
-                partial_cost = jnp.sum(
-                    state.residual_vector[residual_index : residual_index + stacked_dim]
-                    ** 2
-                )
-                residual_index += stacked_dim
-                jax_log(
-                    "     - "
-                    + f"{f._get_name()}({count}):".ljust(15)
-                    + " {:.5f} (avg {:.5f})",
-                    partial_cost,
-                    partial_cost / stacked_dim,
-                    ordered=True,
-                )
-
+        proposed_vals = state.vals._retract(local_delta, problem.tangent_ordering)
         with jdc.copy_and_mutate(state) as state_next:
-            proposed_residual_vector = problem.compute_residual_vector(vals)
+            proposed_residual_vector, proposed_jac_cache = (
+                problem.compute_residual_vector(proposed_vals, include_jac_cache=True)
+            )
             proposed_cost = jnp.sum(proposed_residual_vector**2)
 
             # Update ATb_norm for Eisenstat-Walker criterion.
@@ -371,7 +344,7 @@ class NonlinearSolver:
 
             # Always accept Gauss-Newton steps.
             if self.trust_region is None:
-                state_next.vals = vals
+                state_next.vals = proposed_vals
                 state_next.residual_vector = proposed_residual_vector
                 state_next.cost = proposed_cost
                 accept_flag = None
@@ -386,27 +359,28 @@ class NonlinearSolver:
                 )
                 accept_flag = step_quality >= self.trust_region.step_quality_min
 
-                state_next.vals = jax.tree.map(
-                    lambda proposed, current: jnp.where(accept_flag, proposed, current),
-                    vals,
-                    state.vals,
-                )
-                state_next.residual_vector = jnp.where(
-                    accept_flag, proposed_residual_vector, state.residual_vector
-                )
-                state_next.cost = jnp.where(accept_flag, proposed_cost, state.cost)
-                state_next.lambd = jnp.where(
-                    accept_flag,
-                    # If accept, decrease damping: note that we *don't* enforce any bounds here
-                    state.lambd / self.trust_region.lambda_factor,
-                    # If reject: increase lambda and enforce bounds
-                    jnp.maximum(
+                # What does the accepted state look like?
+                with jdc.copy_and_mutate(state) as state_accept:
+                    state_accept.vals = proposed_vals
+                    state_accept.residual_vector = proposed_residual_vector
+                    state_accept.cost = proposed_cost
+                    state_accept.jac_cache = proposed_jac_cache
+                    state_accept.lambd = state.lambd / self.trust_region.lambda_factor
+
+                # What does the rejected state look like?
+                with jdc.copy_and_mutate(state) as state_reject:
+                    state_reject.lambd = jnp.maximum(
                         self.trust_region.lambda_min,
                         jnp.minimum(
                             state.lambd * self.trust_region.lambda_factor,
                             self.trust_region.lambda_max,
                         ),
-                    ),
+                    )
+
+                state_next = jax.tree.map(
+                    lambda x, y: jnp.where(accept_flag, x, y),
+                    state_accept,
+                    state_reject,
                 )
 
             # Compute termination criteria.
@@ -423,6 +397,50 @@ class NonlinearSolver:
 
             state_next.iterations += 1
         return state_next
+
+    @staticmethod
+    def _log_state(
+        problem: AnalyzedLeastSquaresProblem, state: NonlinearSolverState
+    ) -> None:
+        if state.cg_state is None:
+            jax_log(
+                " step #{i}: cost={cost:.4f} lambd={lambd:.4f} term_deltas={cost_delta:.1e},{grad_mag:.1e},{param_delta:.1e}",
+                i=state.iterations,
+                cost=state.cost,
+                lambd=state.lambd,
+                cost_delta=state.termination_deltas[0],
+                grad_mag=state.termination_deltas[1],
+                param_delta=state.termination_deltas[2],
+                ordered=True,
+            )
+        else:
+            jax_log(
+                " step #{i}: cost={cost:.4f} lambd={lambd:.4f} term_deltas={cost_delta:.1e},{grad_mag:.1e},{param_delta:.1e} inexact_tol={inexact_tol:.1e}",
+                i=state.iterations,
+                cost=state.cost,
+                lambd=state.lambd,
+                cost_delta=state.termination_deltas[0],
+                grad_mag=state.termination_deltas[1],
+                param_delta=state.termination_deltas[2],
+                inexact_tol=state.cg_state.eta,
+                ordered=True,
+            )
+        residual_index = 0
+        for f, count in zip(problem.stacked_costs, problem.cost_counts):
+            stacked_dim = count * f.residual_flat_dim
+            partial_cost = jnp.sum(
+                state.residual_vector[residual_index : residual_index + stacked_dim]
+                ** 2
+            )
+            residual_index += stacked_dim
+            jax_log(
+                "     - "
+                + f"{f._get_name()}({count}):".ljust(15)
+                + " {:.5f} (avg {:.5f})",
+                partial_cost,
+                partial_cost / stacked_dim,
+                ordered=True,
+            )
 
 
 @jdc.pytree_dataclass


### PR DESCRIPTION
We now have three approaches for specifying Jacobians:

**Automatic Jacobian (existing API)**
```python
@jaxls.Cost.create_factory
def some_cost(values: jaxls.VarValues, *args) -> tuple[jax.Array, Any]:
    ... # Compute residual.
    return residual
```
Additional supported arguments: `jac_mode`, `jac_batch_size`.

**Manual Jacobian (existing API)**
```python
def _custom_jacobian_fn(values: jaxls.VarValues, *args, **kwargs) -> jax.Array:
    ... # Compute Jacobian.
    return jacobian

@jaxls.Cost.create_factory(jac_custom_fn=_custom_jacobian_fn)
def some_cost(values: jaxls.VarValues, *args) -> tuple[jax.Array, Any]:
    ... # Compute residual.
    return residual
```
Additional supported arguments: `jac_batch_size`.

**Manual Jacobian with cache (new API, added in this PR)**
```python
CacheType = Any  # or whatever

def _custom_jacobian_fn(values: jaxls.VarValues, cache: CacheType, *args, **kwargs) -> jax.Array:
    ... # Compute Jacobian with the aid of `cache`, which is computed in the residual function.
    return jacobian

@jaxls.Cost.create_factory(jac_custom_with_cache_fn=_custom_jacobian_fn)
def some_cost(values: jaxls.VarValues, *args) -> tuple[jax.Array, CacheType]:
    ... # Compute residual, cache
    return residual, cache
```
Additional supported arguments: `jac_batch_size`.